### PR TITLE
Launch Rviz as anonymous node

### DIFF
--- a/psen_scan_tutorials/launch/psen_scan.launch
+++ b/psen_scan_tutorials/launch/psen_scan.launch
@@ -8,7 +8,7 @@
   </node>
   <!-- %EndTag(PSEN_SCAN_NODE)% -->
   <!-- %Tag(RVIZ)% -->
-  <node name="rviz" type="rviz" pkg="rviz" args="-d $(find psen_scan)/config/config.rviz" />
+  <node name="$(anon rviz)" type="rviz" pkg="rviz" args="-d $(find psen_scan)/config/config.rviz" />
   <!-- %EndTag(RVIZ)% -->
 </launch>
 <!-- %EndTag(FULLTEXT)% -->

--- a/psen_scan_tutorials/launch/two_scanners.launch
+++ b/psen_scan_tutorials/launch/two_scanners.launch
@@ -11,6 +11,6 @@
   <node name="laser_scanner2" type="psen_scan_node" pkg="psen_scan" output="screen" required="true">
     <rosparam command="load" file="$(find psen_scan_tutorials)/config/scanner2_config.yaml" />
   </node>
-  <node name="rviz" type="rviz" pkg="rviz" args="-d $(find psen_scan)/config/config.rviz" />
+  <node name="$(anon rviz)" type="rviz" pkg="rviz" args="-d $(find psen_scan)/config/config.rviz" />
 </launch>
 <!-- %EndTag(FULLTEXT)% -->


### PR DESCRIPTION
Hint from Joachim:
usually rviz ist started as anonymouos node to allow several instances. 

See:
https://github.com/PilzDE/pilz_robots/blob/ee71798ea49a12b5efb462d52f6969ab3daf615a/prbt_moveit_config/launch/moveit_rviz.launch#L11